### PR TITLE
Bugfix: Send request body as form params

### DIFF
--- a/src/ChargeBee.php
+++ b/src/ChargeBee.php
@@ -64,7 +64,7 @@ class ChargeBee
     public function post(string $endpoint, array $params): Response
     {
         return $this->request('POST', $endpoint, [
-            'json' => $params,
+            'form_params' => $params,
         ]);
     }
 

--- a/tests/ChargebeeTest.php
+++ b/tests/ChargebeeTest.php
@@ -114,7 +114,8 @@ final class ChargebeeTest extends TestCase
         $this->assertEquals('/api/v2/subscription', $request->getUri()->getPath());
         $this->assertEquals('site.chargebee.com', $request->getUri()->getHost());
         $this->assertEquals(['Basic '.base64_encode('api-key:')], $request->getHeader('Authorization'));
-        $this->assertEquals(json_encode($body), $request->getBody());
+        parse_str(urldecode($request->getBody()->getContents()), $result);
+        $this->assertEquals($body, $result);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(['test' => 'test2'], $response->getParsedBody());
     }


### PR DESCRIPTION
The Chargebee API can't work with JSON bodies in their requests. You have to send them as URL decoded form params. This PR fixes the issue.

---

Closes #8 